### PR TITLE
Clean up confluence tags and added caution

### DIFF
--- a/help/marketo/product-docs/email-marketing/general/email-editor-2/email-template-syntax.md
+++ b/help/marketo/product-docs/email-marketing/general/email-editor-2/email-template-syntax.md
@@ -50,7 +50,7 @@ The content within the HTML element (if provided) with class="mktEditable" will 
 
 Example:
 
-`<pre data-theme="Confluence"><div class="mktEditable" id="exampleText" mktoName="Main Body Text"> Optionally add default text for the editable text area. </div></pre>`
+`<div class="mktEditable" id="exampleText" mktoName="Main Body Text"> Optionally add default text for the editable text area. </div>`
 
 ### Option 2 - mktoText {#option-mktotext}
 
@@ -68,7 +68,7 @@ The content within the HTML element (if provided) with class="mktoText" will be 
 
 Example:
 
-`<pre data-theme="Confluence"><div class="mktoText" id="exampleText" mktoName="Main Body Text"> Optionally add default text for the editable text area. </div></pre>`
+`<div class="mktoText" id="exampleText" mktoName="Main Body Text"> Optionally add default text for the editable text area. </div>`
 
 ## Images {#images}
 
@@ -99,7 +99,7 @@ Default value (optional)
 
 Example:
 
-`<pre data-theme="Confluence"><div class="mktoImg" id="exampleImg" mktoName="Example Image" mktoImgLink="https://www.marketo.com"> <a><img style="border:10px solid red;"></a> </div></pre>`
+`<div class="mktoImg" id="exampleImg" mktoName="Example Image" mktoImgLink="https://www.marketo.com"> <a><img style="border:10px solid red;"></a> </div>`
 
 ### Option 2 - Use an \<img\> {#option-use-an-img}
 
@@ -117,7 +117,7 @@ Required attributes
 * **mktoLockImgStyle:** Used to lock the `<img>` element's style property (default is false).
 
 Example:
-`<pre data-theme="Confluence"><img class="mktoImg" id="exampleImg" mktoName="Example Image"></pre>`
+`<img class="mktoImg" id="exampleImg" mktoName="Example Image">`
 
 ## Snippets {#snippets}
 
@@ -134,7 +134,7 @@ Default value (optional)
 
 Example:
 
-`<pre data-theme="Confluence"><div class="mktoSnippet" id="unsubscribeFooter" mktoName="Unsubscribe Footer" mktoDefaultSnippetId="12"></div></pre>`
+`<div class="mktoSnippet" id="unsubscribeFooter" mktoName="Unsubscribe Footer" mktoDefaultSnippetId="12"></div>`
 
 ## Video {#video}
 
@@ -151,7 +151,7 @@ Optional attributes
 
 Example:
 
-`<pre data-theme="Confluence"><div class="mktoVideo" id="productVideo" mktoName="Product Announcement Video"></div></pre>`
+`<div class="mktoVideo" id="productVideo" mktoName="Product Announcement Video"></div>`
 
 ## Variables {#variables}
 
@@ -174,11 +174,11 @@ Optional attributes
 
 Example Declaration:
 
-`<pre data-theme="Confluence"><meta class="mktoString" id="textHeader" mktoName="Text Header" default="Edit Me"></pre>`
+`<meta class="mktoString" id="textHeader" mktoName="Text Header" default="Edit Me">`
 
 Example Usage:
 
-`<pre data-theme="Confluence">${textHeader}</pre>`
+`${textHeader}`
 
 ## List {#list}
 
@@ -197,11 +197,11 @@ Optional attributes
 
 Example Declaration:
 
-`<pre data-theme="Confluence"><meta class="mktoList" id="textFontFamily" mktoName="Main Text Font Family" values="Arial,Verdana,Times New Roman"></pre>`
+`<meta class="mktoList" id="textFontFamily" mktoName="Main Text Font Family" values="Arial,Verdana,Times New Roman">`
 
 Example Usage:
 
-`<pre data-theme="Confluence">${textFontFamily}</pre>`
+`${textFontFamily}`
 
 ## Number {#number}
 
@@ -223,11 +223,11 @@ Optional attributes
 
 Example Declaration:
 
-`<pre data-theme="Confluence"><meta class="mktoNumber" id="textFontSize" mktoName="Main Text Font Size" default="12" min="8" max="18" units="px" step="1"> </pre>`
+`<meta class="mktoNumber" id="textFontSize" mktoName="Main Text Font Size" default="12" min="8" max="18" units="px" step="1"> `
 
 Example Usage:
 
-`<pre data-theme="Confluence">${textFontSize}</pre>`
+`${textFontSize}`
 
 ## Color {#color}
 
@@ -245,11 +245,11 @@ Optional attributes
 
 Example Declaration:
 
-`<pre data-theme="Confluence"><meta class="mktoColor" id="textColor" mktoName="Main Text Color" default="#FFFFFF"></pre>`
+`<meta class="mktoColor" id="textColor" mktoName="Main Text Color" default="#FFFFFF">`
 
 Example Usage:
 
-`<pre data-theme="Confluence">${textColor}</pre>`
+`${textColor}`
 
 ## Boolean {#boolean}
 
@@ -271,11 +271,11 @@ Optional attributes
 
 Example Declaration:
 
-`<pre data-theme="Confluence"><meta class="mktoBoolean" id="showFooter" mktoName="Show Footer BG?" default="false" false_value="transparent" true_value="black" false_value_name="NO" true_value_name="YES"></pre>`
+`<meta class="mktoBoolean" id="showFooter" mktoName="Show Footer BG?" default="false" false_value="transparent" true_value="black" false_value_name="NO" true_value_name="YES">`
 
 Example Usage:
 
-`<pre data-theme="Confluence">${showFooter}</pre>`
+`${showFooter}`
 
 ## HTML Block {#html-block}
 
@@ -293,11 +293,11 @@ Optional attributes
 
 Example Declaration:
 
-`<pre data-theme="Confluence"><meta class="mktoHTML" id="trackingPixel" mktoName="Add Tracking Pixel"></pre>`
+`<meta class="mktoHTML" id="trackingPixel" mktoName="Add Tracking Pixel">`
 
 Example Usage:
 
-`<pre data-theme="Confluence">${trackingPixel}</pre>`
+`${trackingPixel}`
 
 ## Image Variable {#image-variable}
 
@@ -315,11 +315,11 @@ Optional attributes
 
 Example Declaration:
 
-`<pre data-theme="Confluence"><meta class="mktoImg" id="heroBackgroundImage" mktoName="Hero Background Image" default="https://www.company.com/image.jpg"></pre>`
+`<meta class="mktoImg" id="heroBackgroundImage" mktoName="Hero Background Image" default="https://www.company.com/image.jpg">`
 
 Example Usage:
 
-`<pre data-theme="Confluence">${heroBackgroundImage}</pre>`
+`${heroBackgroundImage}`
 
 ## Modules {#modules}
 
@@ -364,3 +364,7 @@ Required attributes
 >[!CAUTION]
 >
 >Containers can only contain Modules-if there's anything else present, the Container is considered invalid! Only one container is allowed per template.
+
+>[!CAUTION]
+>
+>It is recommended to not re-approve an email template asset once it is used by more than 500 email assets. This may cause performance issues.


### PR DESCRIPTION
- removed pre-tags with confluence references that displayed incorrectly on https://experienceleague.adobe.com/docs/marketo/using/product-docs/email-marketing/general/email-editor-2/email-template-syntax.html
- added caution to not re-approve email templates in certain situations as detailed by the Marketo engineering team