### PR TITLE
Fix static list member cutoff in clone program doc

### DIFF
--- a/help/marketo/product-docs/core-marketo-concepts/programs/working-with-programs/clone-a-program.md
+++ b/help/marketo/product-docs/core-marketo-concepts/programs/working-with-programs/clone-a-program.md
@@ -23,7 +23,7 @@ Quickly and easily clone an entire program and all its assets instead of manuall
 
    >[!NOTE]
    >
-   >See that [!UICONTROL NOTE] in the screenshot above? It means if you clone a program with 1000 or more people in a list, the list itself will get cloned, but it will be empty. If you clone a program with a list that contains 999 people or less, that list, along with all of its members, will show up in the cloned program.
+   >See that [!UICONTROL NOTE] in the screenshot above? It means if you clone a program with more than 1000 people in a list, the list itself will get cloned, but it will be empty. If you clone a program with a list that contains 1000 people or less, that list, along with all of its members, will show up in the cloned program.
 
 1. Enter a **[!UICONTROL Name]**.
 


### PR DESCRIPTION
## Summary

Fixes #58 — corrects the static list member cutoff threshold in the "Clone a Program" documentation.

**Before:** States lists with "1000 or more" people are cloned empty, and "999 or less" carry over.
**After:** States lists with "more than 1000" people are cloned empty, and "1000 or less" carry over.

As confirmed by @lbeasley-adobe (Adobe Marketo TSE) in #58, the actual behavior is that a static list with exactly 1000 members **does** carry over when cloning. The cutoff for an empty clone is 1001+.

## Test plan

- [ ] Verify the rendered note on the [Clone a Program](https://experienceleague.adobe.com/en/docs/marketo/using/core-marketo-concepts/programs/working-with-programs/clone-a-program) page reflects the corrected threshold