### PR TITLE
Fix typos, outdated refs, and copy-paste errors across 7 docs

### DIFF
--- a/help/marketo/product-docs/administration/email-setup/filtering-email-bot-activity.md
+++ b/help/marketo/product-docs/administration/email-setup/filtering-email-bot-activity.md
@@ -53,7 +53,7 @@ Against email link click and email open activity, new attributes will be populat
 >
 >* If you choose [!UICONTROL Filter Bot Activity], you may see a drop in email opens and clicks as false activities are weeded out.
 
-**OPTIONAL STEP**: To disable either feature, simply deselect the resective slider. If you do, the data does not reset.
+**OPTIONAL STEP**: To disable either feature, simply deselect the respective slider. If you do, the data does not reset.
 
 >[!TIP]
 >

--- a/help/marketo/product-docs/administration/field-management/create-a-custom-field-in-marketo.md
+++ b/help/marketo/product-docs/administration/field-management/create-a-custom-field-in-marketo.md
@@ -51,6 +51,6 @@ If you need a new custom field in Marketo Engage to store/capture data, here's h
 
 >[!NOTE]
 >
->The API name is used by the SOAP API and other backend processes.
+>The API name is used by the REST API and other backend processes.
 
 You can now use this custom field in forms, flow steps, and Smart Lists!

--- a/help/marketo/product-docs/administration/field-management/mark-a-field-as-sensitive.md
+++ b/help/marketo/product-docs/administration/field-management/mark-a-field-as-sensitive.md
@@ -8,10 +8,6 @@ feature: Field Management
 
 As a Marketo Admin, you can mark a specific field as "sensitive" so its values never get pre-filled in forms, thereby protecting users' sensitive data.
 
->[!NOTE]
->
->This feature will be enabled for all Marketo instances on the evening of Tuesday, May 11.
-
 1. Click **[!UICONTROL Admin]**.
 
    ![](assets/mark-a-field-as-sensitive-1.png)

--- a/help/marketo/product-docs/administration/field-management/understanding-system-managed-fields.md
+++ b/help/marketo/product-docs/administration/field-management/understanding-system-managed-fields.md
@@ -123,7 +123,7 @@ Below are some possible values and what they mean.
   </tr>
   <tr>
     <td>Contact</td>
-    <td>Person was synced over from Webhook as a contact</td>
+    <td>Person was synced over from Salesforce as a contact</td>
   </tr>
   <tr>
     <td>Munchkin API</td>

--- a/help/marketo/product-docs/core-marketo-concepts/smart-campaigns/using-smart-campaigns/edit-qualification-rules-in-a-smart-campaign.md
+++ b/help/marketo/product-docs/core-marketo-concepts/smart-campaigns/using-smart-campaigns/edit-qualification-rules-in-a-smart-campaign.md
@@ -29,8 +29,4 @@ Qualification rules control how many times someone can run through the flow in a
    >
    >Communication limits are not applied to Smart Campaigns by default. Learn how to [apply communication limits to a Smart Campaign](/help/marketo/product-docs/core-marketo-concepts/smart-campaigns/using-smart-campaigns/apply-communication-limits-to-smart-campaign.md){target="_blank"}.
 
-   >[!NOTE]
-   >
-   >[Apply Communication Limits to Smart Campaigns](/help/marketo/product-docs/core-marketo-concepts/smart-campaigns/using-smart-campaigns/apply-communication-limits-to-smart-campaign.md){target="_blank"}
-
 Mission accomplished! You now know how to control qualification rules in a Smart Campaign.

--- a/help/marketo/product-docs/demand-generation/landing-pages/landing-page-templates/create-a-guided-landing-page-template.md
+++ b/help/marketo/product-docs/demand-generation/landing-pages/landing-page-templates/create-a-guided-landing-page-template.md
@@ -186,8 +186,6 @@ Optional:
 
 Basic Example:
 
-`<meta class="mktoColor" id="color" mktoName="My Color Variable" default="#336699">`
-
 `<meta class="mktoBoolean" id="boolean1" mktoName="My Boolean Variable">`
 
 Example with all attributes:

--- a/help/marketo/product-docs/email-marketing/deliverability/shared-and-dedicated-ip-addresses.md
+++ b/help/marketo/product-docs/email-marketing/deliverability/shared-and-dedicated-ip-addresses.md
@@ -34,7 +34,7 @@ _Pros_
 _Cons_
 
 **Volume changes** - Spikes in volume can negatively affect your reputation and need to be managed.
-**IP warm-up process** - Reputation is is built over time. Some Internet Service Providers (ISPs) throttle IP addresses with no volume history, so you will have to build a reputation over the first few weeks (Marketo can help guide you).
+**IP warm-up process** - Reputation is built over time. Some Internet Service Providers (ISPs) throttle IP addresses with no volume history, so you will have to build a reputation over the first few weeks (Marketo can help guide you).
 **Cost** - There is usually an additional charge to send from a Dedicated IP with any provider.
 
 **Pros and Cons of a Shared IP**


### PR DESCRIPTION
## Summary

Batch of small corrections found during a documentation audit:

- **Typo fix**: "Reputation is is built" → "Reputation is built" (`shared-and-dedicated-ip-addresses.md`)
- **Typo fix**: "resective" → "respective" (`filtering-email-bot-activity.md`)
- **Duplicate removal**: Removed duplicate communication limits note block (`edit-qualification-rules-in-a-smart-campaign.md`)
- **Outdated reference**: SOAP API → REST API — SOAP has been deprecated (`create-a-custom-field-in-marketo.md`)
- **Stale note removal**: Removed undated "will be enabled on Tuesday, May 11" launch note for a feature that shipped years ago (`mark-a-field-as-sensitive.md`)
- **Inaccurate content**: Contact source type listed as "Webhook" — contacts sync from Salesforce CRM, not webhooks (`understanding-system-managed-fields.md`)
- **Copy-paste error**: Boolean variable section showed an mktoColor example instead of mktoBoolean (`create-a-guided-landing-page-template.md`)

## Test plan

- [ ] Verify each changed page renders correctly on Experience League
- [ ] Confirm no broken links or formatting issues from the removals