### PR TITLE
Fix outdated SOAP ref, informal tone, and missing headings

### DIFF
--- a/help/marketo/product-docs/administration/users-and-roles/descriptions-of-role-permissions.md
+++ b/help/marketo/product-docs/administration/users-and-roles/descriptions-of-role-permissions.md
@@ -209,7 +209,7 @@ View the Marketing Activities tab, campaigns, and campaign folders.
 * List Import
 * Schedule Batch Campaign
 
-Access SEO
+## Access SEO {#access-seo}
 
 * Administer SEO
 * Standard SEO
@@ -222,7 +222,7 @@ Access SEO
 * Web Campaign Editor
 * Web Campaign Launcher
 
-Workspace Administration
+## Workspace Administration {#workspace-administration}
 
 * Admin access for a specific Workspace (only if you have Workspaces enabled)
 * Move assets between Workspaces (only if you have Workspaces enabled)

--- a/help/marketo/product-docs/administration/workspaces-and-person-partitions/assigning-person-partitions-with-assignment-rules.md
+++ b/help/marketo/product-docs/administration/workspaces-and-person-partitions/assigning-person-partitions-with-assignment-rules.md
@@ -19,7 +19,7 @@ When using person partitions, set up assignment rules to route people created fr
 
 >[!NOTE]
 >
->Only people created in Marketo from your CRM and via the SOAP API will have assignment rules applied to them.
+>Only people created in Marketo from your CRM and via the REST API will have assignment rules applied to them.
 
 1. Go to the **[!UICONTROL Admin]** area.
 

--- a/help/marketo/product-docs/demand-generation/forms/form-fields/set-a-hidden-form-field-value.md
+++ b/help/marketo/product-docs/demand-generation/forms/form-fields/set-a-hidden-form-field-value.md
@@ -31,7 +31,7 @@ If you want to capture URL Parameters (Query Strings) from the page the person i
 
 >[!NOTE]
 >
->Parameters are kinda techie, aren't they? Once you get them though, they are powerful. This [Wikipedia page on Query Strings](https://en.wikipedia.org/wiki/Query_string) is somewhat helpful.
+>Parameters are used to pass data through URLs. This [Wikipedia page on Query Strings](https://en.wikipedia.org/wiki/Query_string) provides a helpful overview.
 
 1. Select **[!UICONTROL URL Parameter]** for **[!UICONTROL Get Value Type]**.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Second batch of corrections from a documentation audit:

- **Outdated reference**: SOAP API → REST API — SOAP has been deprecated (`assigning-person-partitions-with-assignment-rules.md`)
- **Tone improvement**: Replaced informal "Parameters are kinda techie, aren't they?" with professional language (`set-a-hidden-form-field-value.md`)
- **Formatting fix**: Added missing `##` heading markers for "Access SEO" and "Workspace Administration" sections, which broke the document's heading hierarchy and anchor links (`descriptions-of-role-permissions.md`)

## Test plan

- [ ] Verify anchor links to `#access-seo` and `#workspace-administration` work on the rendered page
- [ ] Confirm no formatting regressions on the role permissions page