### PR TITLE
Add critical stream transition behavior notes to engagement programs

### DIFF
--- a/help/marketo/product-docs/demand-generation/forms/form-actions/configure-form-progressive-profiling.md
+++ b/help/marketo/product-docs/demand-generation/forms/form-actions/configure-form-progressive-profiling.md
@@ -91,11 +91,3 @@ Short forms are good! When someone comes back to a form, you can present new fie
 Nice job! The work you just did will pay off.
 
 Experiment with this feature and be sure to test. It's advanced, but you can make your forms very dynamic this way.
-
->[!CAUTION]
->
->Progressive profiling relies on the Munchkin cookie to identify returning visitors. If the form is embedded on an external (non-Marketo) page where the Munchkin tracking code is not installed, progressive profiling will not function — all fields will display every time regardless of what data has already been captured. Make sure the Munchkin tracking snippet is present on every page that hosts a progressive profiling form.
-
->[!NOTE]
->
->Progressive profiling does not work in forms embedded within emails. Email clients strip the JavaScript required for progressive profiling to function. For email-embedded forms, all fields will always be shown.

--- a/help/marketo/product-docs/demand-generation/forms/form-actions/configure-form-progressive-profiling.md
+++ b/help/marketo/product-docs/demand-generation/forms/form-actions/configure-form-progressive-profiling.md
@@ -91,3 +91,11 @@ Short forms are good! When someone comes back to a form, you can present new fie
 Nice job! The work you just did will pay off.
 
 Experiment with this feature and be sure to test. It's advanced, but you can make your forms very dynamic this way.
+
+>[!CAUTION]
+>
+>Progressive profiling relies on the Munchkin cookie to identify returning visitors. If the form is embedded on an external (non-Marketo) page where the Munchkin tracking code is not installed, progressive profiling will not function — all fields will display every time regardless of what data has already been captured. Make sure the Munchkin tracking snippet is present on every page that hosts a progressive profiling form.
+
+>[!NOTE]
+>
+>Progressive profiling does not work in forms embedded within emails. Email clients strip the JavaScript required for progressive profiling to function. For email-embedded forms, all fields will always be shown.

--- a/help/marketo/product-docs/email-marketing/drip-nurturing/engagement-program-streams/transition-people-between-engagement-streams.md
+++ b/help/marketo/product-docs/email-marketing/drip-nurturing/engagement-program-streams/transition-people-between-engagement-streams.md
@@ -48,3 +48,15 @@ Engagement programs can have more than one stream. If you [add a stream](/help/m
    >[!NOTE]
    >
    >The steps outlined above *do* apply to people who are [on pause](/help/marketo/product-docs/email-marketing/drip-nurturing/using-engagement-programs/pause-people-in-an-engagement-program.md) as well.
+
+>[!NOTE]
+>
+>Transition rules are evaluated at **cast time**, not in real time. If a person qualifies for a transition mid-cast, they still receive the current stream's content for that cast and move to the new stream before the next cast.
+
+>[!NOTE]
+>
+>A person can only belong to **one stream at a time** within an engagement program. They are never in multiple streams simultaneously.
+
+>[!IMPORTANT]
+>
+>When a person transitions to a new stream, they begin receiving content **from the top of that stream**. Even if they have exhausted all content in their current stream, the transition resets their position in the new stream.


### PR DESCRIPTION
## Summary

Adds three missing behavioral notes to the engagement program stream transition documentation that practitioners frequently discover through trial and error:

- **Cast-time evaluation**: Transition rules evaluate at cast time, not in real time. A person who qualifies mid-cast still receives the current stream's content for that cast and moves to the new stream before the next cast.
- **Single-stream membership**: A person can only belong to one stream at a time — they are never in multiple streams simultaneously.
- **Position reset on transition**: When a person transitions to a new stream, they start receiving content from the top of that stream, even if they had exhausted all content in their previous stream.

These are common gotchas that cause unexpected behavior in production engagement programs, especially around exhaustion handling and transition timing.

## Test plan

- [ ] Verify callout blocks render correctly on the Experience League page
- [ ] Confirm no formatting issues with the existing content above