### PR TITLE
Document email program membership gap for blocked/unsubscribed people

### DIFF
--- a/help/marketo/product-docs/core-marketo-concepts/programs/creating-programs/understanding-program-membership.md
+++ b/help/marketo/product-docs/core-marketo-concepts/programs/creating-programs/understanding-program-membership.md
@@ -30,6 +30,14 @@ feature: Programs
 >
 >For an email program, a person is added to membership only when the email is sent.
 
+>[!CAUTION]
+>
+>People who are blocked by communication limits, are unsubscribed, or are marketing suspended will NOT become members of the email program — they are skipped entirely. This means their interaction is not captured in program reporting, which can affect attribution accuracy.
+
+>[!NOTE]
+>
+>For engagement programs, a person becomes a member when they are first added to the program via a flow step, not when they receive their first email. This is different from email programs.
+
 ## Program Statuses {#program-statuses}
 
 Program statuses are the steps people go through in a program (e.g., Invited, RSVP'd, Attended, No Show). These steps are defined by the [channel](/help/marketo/product-docs/administration/tags/create-a-program-channel.md){target="_blank"}.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds two missing callouts to the program membership documentation:

- **`[!CAUTION]`**: People blocked by communication limits, unsubscribed, or marketing suspended are skipped entirely from email program membership. This means their interaction is not captured in program reporting, which can silently affect attribution accuracy. This is a known operational gotcha that's not documented.
- **`[!NOTE]`**: Engagement program membership is granted when a person is added via a flow step, not when they receive their first email — clarifying a key behavioral difference from email programs.

## Test plan

- [ ] Verify callout blocks render correctly on the Experience League page
- [ ] Confirm placement is logical (after the existing email program membership note)