### PR TITLE
Document progressive profiling failure modes (Munchkin, email)

### DIFF
--- a/help/marketo/product-docs/demand-generation/forms/form-actions/configure-form-progressive-profiling.md
+++ b/help/marketo/product-docs/demand-generation/forms/form-actions/configure-form-progressive-profiling.md
@@ -91,3 +91,11 @@ Short forms are good! When someone comes back to a form, you can present new fie
 Nice job! The work you just did will pay off.
 
 Experiment with this feature and be sure to test. It's advanced, but you can make your forms very dynamic this way.
+
+>[!CAUTION]
+>
+>Progressive profiling relies on the Munchkin cookie to identify returning visitors. If the form is embedded on an external (non-Marketo) page where the Munchkin tracking code is not installed, progressive profiling will not function — all fields will display every time regardless of what data has already been captured. Make sure the Munchkin tracking snippet is present on every page that hosts a progressive profiling form.
+
+>[!NOTE]
+>
+>Progressive profiling does not work in forms embedded within emails. Email clients strip the JavaScript required for progressive profiling to function. For email-embedded forms, all fields will always be shown.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds two missing failure-mode warnings to the progressive profiling documentation:

- **`[!CAUTION]`**: Progressive profiling relies on the Munchkin cookie. If the form is embedded on an external page without the Munchkin tracking snippet installed, progressive profiling fails silently — all fields display every time regardless of previously captured data.
- **`[!NOTE]`**: Progressive profiling does not work in forms embedded within emails. Email clients strip the JavaScript required for it to function, so all fields will always be shown.

These are the two most common failure modes for progressive profiling in production and are currently undocumented.

## Test plan

- [ ] Verify callout blocks render correctly on the Experience League page
- [ ] Confirm no formatting issues with the existing content