### PR TITLE
Add one-click unsubscribe (List-Unsubscribe-Post) documentation

### DIFF
--- a/help/marketo/product-docs/demand-generation/forms/form-actions/configure-form-progressive-profiling.md
+++ b/help/marketo/product-docs/demand-generation/forms/form-actions/configure-form-progressive-profiling.md
@@ -91,11 +91,3 @@ Short forms are good! When someone comes back to a form, you can present new fie
 Nice job! The work you just did will pay off.
 
 Experiment with this feature and be sure to test. It's advanced, but you can make your forms very dynamic this way.
-
->[!CAUTION]
->
->Progressive profiling relies on the Munchkin cookie to identify returning visitors. If the form is embedded on an external (non-Marketo) page where the Munchkin tracking code is not installed, progressive profiling will not function — all fields will display every time regardless of what data has already been captured. Make sure the Munchkin tracking snippet is present on every page that hosts a progressive profiling form.
-
->[!NOTE]
->
->Progressive profiling does not work in forms embedded within emails. Email clients strip the JavaScript required for progressive profiling to function. For email-embedded forms, all fields will always be shown.

--- a/help/marketo/product-docs/demand-generation/forms/form-actions/configure-form-progressive-profiling.md
+++ b/help/marketo/product-docs/demand-generation/forms/form-actions/configure-form-progressive-profiling.md
@@ -91,3 +91,11 @@ Short forms are good! When someone comes back to a form, you can present new fie
 Nice job! The work you just did will pay off.
 
 Experiment with this feature and be sure to test. It's advanced, but you can make your forms very dynamic this way.
+
+>[!CAUTION]
+>
+>Progressive profiling relies on the Munchkin cookie to identify returning visitors. If the form is embedded on an external (non-Marketo) page where the Munchkin tracking code is not installed, progressive profiling will not function — all fields will display every time regardless of what data has already been captured. Make sure the Munchkin tracking snippet is present on every page that hosts a progressive profiling form.
+
+>[!NOTE]
+>
+>Progressive profiling does not work in forms embedded within emails. Email clients strip the JavaScript required for progressive profiling to function. For email-embedded forms, all fields will always be shown.

--- a/help/marketo/product-docs/email-marketing/deliverability/understanding-unsubscribe.md
+++ b/help/marketo/product-docs/email-marketing/deliverability/understanding-unsubscribe.md
@@ -31,4 +31,20 @@ This status blocks a person from mailings for 24 hours after a hard bounce occur
 
 [Use this for people like competitors](/help/marketo/product-docs/core-marketo-concepts/smart-lists-and-static-lists/managing-people-in-smart-lists/add-person-to-blocklist.md). Anyone you want receiving **no** emails—operational, marketing, etc. They get nothing!
 
+## One-Click Unsubscribe (List-Unsubscribe) {#one-click-unsubscribe}
+
+>[!IMPORTANT]
+>
+>As of February 2024, Gmail and Yahoo require bulk senders (5,000+ messages/day) to support one-click unsubscribe via the `List-Unsubscribe-Post` header (RFC 8058). This allows recipients to unsubscribe directly from the email client without visiting a landing page.
+
+Marketo Engage automatically includes the `List-Unsubscribe` header in outgoing emails. The `List-Unsubscribe-Post` header enables one-click unsubscribe directly in the inbox (the "Unsubscribe" button in Gmail, Yahoo, etc.). When a recipient uses this button, Marketo sets the person's **Unsubscribed** field to true.
+
+>[!NOTE]
+>
+>One-click unsubscribe is separate from the unsubscribe link in your email body. Even if your email template includes an unsubscribe link, the List-Unsubscribe header provides an additional unsubscribe mechanism at the mail-client level that recipients may use instead.
+
+>[!TIP]
+>
+>To verify that your emails include the proper headers, send a test email to a Gmail address and view the original message headers (three-dot menu > Show Original). Look for both `List-Unsubscribe` and `List-Unsubscribe-Post` headers.
+
 ![](assets/image2015-5-18-12-3a6-3a40.png)

--- a/help/marketo/product-docs/email-marketing/drip-nurturing/engagement-program-streams/transition-people-between-engagement-streams.md
+++ b/help/marketo/product-docs/email-marketing/drip-nurturing/engagement-program-streams/transition-people-between-engagement-streams.md
@@ -48,15 +48,3 @@ Engagement programs can have more than one stream. If you [add a stream](/help/m
    >[!NOTE]
    >
    >The steps outlined above *do* apply to people who are [on pause](/help/marketo/product-docs/email-marketing/drip-nurturing/using-engagement-programs/pause-people-in-an-engagement-program.md) as well.
-
->[!NOTE]
->
->Transition rules are evaluated at **cast time**, not in real time. If a person qualifies for a transition mid-cast, they still receive the current stream's content for that cast and move to the new stream before the next cast.
-
->[!NOTE]
->
->A person can only belong to **one stream at a time** within an engagement program. They are never in multiple streams simultaneously.
-
->[!IMPORTANT]
->
->When a person transitions to a new stream, they begin receiving content **from the top of that stream**. Even if they have exhausted all content in their current stream, the transition resets their position in the new stream.

--- a/help/marketo/product-docs/email-marketing/drip-nurturing/engagement-program-streams/transition-people-between-engagement-streams.md
+++ b/help/marketo/product-docs/email-marketing/drip-nurturing/engagement-program-streams/transition-people-between-engagement-streams.md
@@ -48,3 +48,15 @@ Engagement programs can have more than one stream. If you [add a stream](/help/m
    >[!NOTE]
    >
    >The steps outlined above *do* apply to people who are [on pause](/help/marketo/product-docs/email-marketing/drip-nurturing/using-engagement-programs/pause-people-in-an-engagement-program.md) as well.
+
+>[!NOTE]
+>
+>Transition rules are evaluated at **cast time**, not in real time. If a person qualifies for a transition mid-cast, they still receive the current stream's content for that cast and move to the new stream before the next cast.
+
+>[!NOTE]
+>
+>A person can only belong to **one stream at a time** within an engagement program. They are never in multiple streams simultaneously.
+
+>[!IMPORTANT]
+>
+>When a person transitions to a new stream, they begin receiving content **from the top of that stream**. Even if they have exhausted all content in their current stream, the transition resets their position in the new stream.


### PR DESCRIPTION
## Summary

Adds a new section to the "Understanding Unsubscribe" page documenting one-click unsubscribe via the `List-Unsubscribe-Post` header (RFC 8058).

**Why this matters:** Since February 2024, Gmail and Yahoo require bulk senders to support one-click unsubscribe. The existing unsubscribe documentation covers the Marketo fields (Unsubscribed, Marketing Suspended, Email Suspended, Blocklisted) but has no mention of this mail-client-level mechanism or the compliance requirement.

**What's added:**
- `[!IMPORTANT]` callout on the Gmail/Yahoo Feb 2024 requirement
- Explanation of how Marketo automatically includes `List-Unsubscribe` and `List-Unsubscribe-Post` headers
- `[!NOTE]` distinguishing header-level unsubscribe from in-body unsubscribe links
- `[!TIP]` with verification steps via Gmail "Show Original"

## Test plan

- [ ] Verify the new section renders correctly between Blocklisted and the closing screenshot
- [ ] Confirm callout blocks display with correct styling