### PR TITLE
Sync IP allowlist between Setup Steps and Configure Protocols (#71)

### DIFF
--- a/help/marketo/getting-started/initial-setup/configure-protocols-for-marketo.md
+++ b/help/marketo/getting-started/initial-setup/configure-protocols-for-marketo.md
@@ -70,6 +70,8 @@ Add these IP addresses to your corporate allowlist:
 
 192.28.160.0/19
 
+94.236.119.0/26
+
 199.15.212.0/22
 
 Some anti-spam systems use the email Return-Path field instead of the IP address for allowisting. In those cases, the best approach is to allowlist '&#42;.mktomail.com', as Marketo Engage uses several mailbox subdomains. Other anti-spam systems allowlist based on the From address. In these situations, be sure to include all the sending ('From') domains that your Marketing group uses to communicate with people/leads.

--- a/help/marketo/getting-started/initial-setup/setup-steps.md
+++ b/help/marketo/getting-started/initial-setup/setup-steps.md
@@ -153,6 +153,8 @@ Configure your domain settings so landing pages use your company's domain instea
 
       130.248.173.0/24
 
+      130.248.244.88/29
+
       94.236.119.0/26
 
    >[!NOTE]


### PR DESCRIPTION
## Summary
Fixes #71 — The IP allowlist was inconsistent between the two setup pages.

- Added `130.248.244.88/29` to `setup-steps.md` (was only in Configure Protocols)
- Added `94.236.119.0/26` to `configure-protocols-for-marketo.md` (was only in Setup Steps)

Both pages now list identical IP ranges.

## Test plan
- [ ] Verify both pages show the same IP ranges on Experience League