### PR TITLE
Clarify custom field metric limitations in RCE analysis areas (#64)

### DIFF
--- a/help/marketo/product-docs/reporting/revenue-cycle-analytics/revenue-explorer/sync-custom-fields-to-the-revenue-explorer.md
+++ b/help/marketo/product-docs/reporting/revenue-cycle-analytics/revenue-explorer/sync-custom-fields-to-the-revenue-explorer.md
@@ -37,6 +37,10 @@ feature: Reporting, Revenue Cycle Analytics
 
    ![](assets/image2014-9-19-9-3a51-3a52.png)
 
+   >[!NOTE]
+   >
+   >Custom fields can be synced as both dimensions and metrics to the Lead Analysis, Email Analysis, and Program Membership Analysis areas. However, for the Opportunity Analysis and Program Opportunity Analysis areas, custom fields can only be synced as **dimensions**, not metrics.
+
    >[!TIP]
    >
    >Once enabled, the data will be available in [!UICONTROL Revenue Cycle Analytics] the following day.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Fixes #64 — The RCE custom field sync doc implied custom fields could be added as metrics in all analysis areas. In reality, custom fields can only be added as **dimensions** (not metrics) in Opportunity Analysis and Program Opportunity Analysis. Both dimensions and metrics are only supported in Lead/Email/Program Membership Analysis.

Added a `[!NOTE]` callout clarifying this limitation.

## Test plan
- [ ] Verify callout renders correctly on Experience League