### PR TITLE
Correct available operators for form field visibility rules (#59)

### DIFF
--- a/help/marketo/product-docs/demand-generation/forms/form-fields/dynamically-toggle-visibility-of-a-form-field.md
+++ b/help/marketo/product-docs/demand-generation/forms/form-fields/dynamically-toggle-visibility-of-a-form-field.md
@@ -39,7 +39,7 @@ One really cool feature of Marketo forms is that you can dynamically hide/show f
 
    >[!TIP]
    >
-   >This is cool because you can choose fuzzy matches like "[!UICONTROL starts with]."
+   >The available operators are: **[!UICONTROL Is]**, **[!UICONTROL Is not]**, **[!UICONTROL Is Empty]**, **[!UICONTROL Is Not Empty]**, **[!UICONTROL Contains]**, and **[!UICONTROL Not Contains]**.
 
    ![](assets/image2014-9-15-15-3a16-3a50.png)
 


### PR DESCRIPTION
## Summary
Fixes #59 — The tip claimed "starts with" was available as a fuzzy matching operator for form field visibility rules. The actual available operators are: Is, Is not, Is Empty, Is Not Empty, Contains, and Not Contains.

Corrected the tip to accurately list only the available operators.

## Test plan
- [ ] Verify the corrected tip renders on the Experience League page