### PR TITLE
Add AEM asset approval prerequisite to integration doc (#69)

### DIFF
--- a/help/marketo/product-docs/email-marketing/email-designer/aem-assets.md
+++ b/help/marketo/product-docs/email-marketing/email-designer/aem-assets.md
@@ -15,6 +15,10 @@ Adobe Experience Manager _Assets as a Cloud Service_ offers an easy-to-use cloud
 >
 >* Licenses for _Assets as a Cloud Service_ and Dynamic Media are required for the integration. Ensure that [Dynamic Media with Open API is enabled](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/assets/dynamicmedia/dynamic-media-open-apis/dynamic-media-open-apis-overview#enable-dynamic-media-open-apis). Depending on your contract and configuration, Adobe Experience Manager _Assets as a Cloud Service_ can be accessed directly from Marketo Engage when designing visual content.
 
+>[!IMPORTANT]
+>
+>Assets in your AEM repository must have an **Approved** status before they will be available for use in Marketo Engage. If you've completed the integration setup but don't see any assets, verify that your assets have been approved in AEM.
+
 >[!NOTE]
 >
 >Currently, only image assets from _Adobe Experience Manager Assets_ are supported in Marketo Engage. Changes to the assets must be done from the Adobe Experience Manager Assets central repository. [Learn more](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/assets/manage/manage-digital-assets){target="_blank"}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Fixes #69 — Assets in AEM must have **Approved** status before they appear in Marketo Engage. Users were completing the integration setup but couldn't see any assets because this prerequisite was undocumented.

Added an `[!IMPORTANT]` callout near the top of the setup instructions.

## Test plan
- [ ] Verify callout renders correctly between the prerequisites and existing note