### PR TITLE
Fix CNAME endpoint from MunchkinID to AccountString (#52)

### DIFF
--- a/help/marketo/product-docs/demand-generation/landing-pages/landing-page-actions/customize-your-landing-page-urls-with-a-cname.md
+++ b/help/marketo/product-docs/demand-generation/landing-pages/landing-page-actions/customize-your-landing-page-urls-with-a-cname.md
@@ -25,7 +25,7 @@ Pick a word to go at the beginning of the URL for your landing pages. It's just 
 
 The one word (plus YourCompany.com) is called a CNAME. You'll need this later so make a note of it.
 
-## Find your Munchkin ID {#find-your-munchkin-id}
+## Find your Account String {#find-your-account-string}
 
 1. Go to the **Admin** area.
 
@@ -39,15 +39,15 @@ The one word (plus YourCompany.com) is called a CNAME. You'll need this later so
    >
    >**Admin Permissions Required**
 
-1. Scroll down to "Support Information" and copy your Munchkin ID.
+1. Scroll down to "Support Information" and copy your Account String.
 
    ![](assets/customize-your-landing-page-urls-with-a-cname-3.png)
 
 ## Send Request to IT {#send-request-to-it}
 
-Ask your IT staff to setup the following CNAME: (Replace the word [CNAME] and [Munchkin ID] with the text from the previous step.)
+Ask your IT staff to setup the following CNAME: (Replace the word [CNAME] and [Account String] with the text from the previous step.)
 
-[CNAME].YourCompany.com > [Munchkin ID].mktoweb.com
+[CNAME].YourCompany.com > [Account String].mktoweb.com
 
 ## Complete CNAME Setup {#complete-cname-setup}
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Fixes #52 — The CNAME customization doc incorrectly said the endpoint was `[MunchkinID].mktoweb.com`. The correct endpoint is `[AccountString].mktoweb.com`. These are different values.

Updated the section heading, step instructions, and CNAME target to reference Account String instead of Munchkin ID.

## Test plan
- [ ] Verify the updated instructions are correct on Experience League
- [ ] Confirm the heading anchor `#find-your-account-string` works