### PR TITLE
Fix invalid Company.State token reference (#53)

### DIFF
--- a/help/marketo/product-docs/demand-generation/landing-pages/personalizing-landing-pages/tokens-overview.md
+++ b/help/marketo/product-docs/demand-generation/landing-pages/personalizing-landing-pages/tokens-overview.md
@@ -75,6 +75,7 @@ In this example, the email will say "Greetings, (first name)" or "Greetings, ear
 * `{{lead.Registration Source Info}}`
 * `{{lead.Registration Source Type}}`
 * `{{lead.Salutation}}`
+* `{{lead.State}}`
 * `{{lead.SFDC Created Date}}`
 * `{{lead.SFDC Is Deleted}}`
 * `{{lead.SFDC Type}}`
@@ -102,7 +103,7 @@ In this example, the email will say "Greetings, (first name)" or "Greetings, ear
 * `{{Company.SFDC Type}}`
 * `{{Company.SIC Code}}`
 * `{{Company.Site}}`
-* `{{Company.State}}`
+* `{{Company.BillingState}}`
 * `{{Company.Website}}`
 * Custom company fields also work if you use their display name ex. `{{Company.Custom Field Name}}`
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Fixes #53 — `{{Company.State}}` was listed as a valid Company Token but doesn't exist in Marketo and produces a "Token key not found" error.

- Replaced `{{Company.State}}` with `{{Company.BillingState}}` in the Company Tokens section
- Added `{{lead.State}}` to the Person Tokens section (was missing)

## Test plan
- [ ] Verify the tokens overview page renders correctly on Experience League