### PR TITLE
fix: missing verb 'be' in send-a-sample-email.md

### DIFF
--- a/help/marketo/product-docs/email-marketing/general/creating-an-email/send-a-sample-email.md
+++ b/help/marketo/product-docs/email-marketing/general/creating-an-email/send-a-sample-email.md
@@ -28,7 +28,7 @@ It's quick and easy to send samples of an email. To send a dynamic content email
 
    >[!IMPORTANT]
    >
-   >If you enter multiple email addresses, they will all be visible to every recipient. The first one entered will the main recipient and each subsequent email address will be a CC recipient.
+   >If you enter multiple email addresses, they will all be visible to every recipient. The first one entered will be the main recipient and each subsequent email address will be a CC recipient.
 
    >[!TIP]
    >

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Corrects a missing word in an `>[!IMPORTANT]` callout in `send-a-sample-email.md`
- The sentence read: "The first one entered will the main recipient" — missing the verb "be"
- Corrected to: "The first one entered will **be** the main recipient"

## File changed

`help/marketo/product-docs/email-marketing/general/creating-an-email/send-a-sample-email.md` — line 31