### PR TITLE
fix: missing article 'a' in create-an-email-program.md

### DIFF
--- a/help/marketo/product-docs/email-marketing/email-programs/creating-an-email-program/create-an-email-program.md
+++ b/help/marketo/product-docs/email-marketing/email-programs/creating-an-email-program/create-an-email-program.md
@@ -7,7 +7,7 @@ feature: Email Programs
 ---
 # Create an Email Program {#create-an-email-program}
 
-Use email programs to quickly and easily send an email to group of people.
+Use email programs to quickly and easily send an email to a group of people.
 
 1. Go to **[!UICONTROL Marketing Activities]**.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Corrects a missing article in the opening description of `create-an-email-program.md`
- "send an email to group of people" → "send an email to **a** group of people"

## File changed

`help/marketo/product-docs/email-marketing/email-programs/creating-an-email-program/create-an-email-program.md` — line 10