### PR TITLE
fix: remove duplicate NOTE block in edit-qualification-rules-in-a-smart-campaign.md

### DIFF
--- a/help/marketo/product-docs/core-marketo-concepts/smart-campaigns/using-smart-campaigns/edit-qualification-rules-in-a-smart-campaign.md
+++ b/help/marketo/product-docs/core-marketo-concepts/smart-campaigns/using-smart-campaigns/edit-qualification-rules-in-a-smart-campaign.md
@@ -29,8 +29,4 @@ Qualification rules control how many times someone can run through the flow in a
    >
    >Communication limits are not applied to Smart Campaigns by default. Learn how to [apply communication limits to a Smart Campaign](/help/marketo/product-docs/core-marketo-concepts/smart-campaigns/using-smart-campaigns/apply-communication-limits-to-smart-campaign.md){target="_blank"}.
 
-   >[!NOTE]
-   >
-   >[Apply Communication Limits to Smart Campaigns](/help/marketo/product-docs/core-marketo-concepts/smart-campaigns/using-smart-campaigns/apply-communication-limits-to-smart-campaign.md){target="_blank"}
-
 Mission accomplished! You now know how to control qualification rules in a Smart Campaign.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Removes a redundant `>[!NOTE]` callout block from `edit-qualification-rules-in-a-smart-campaign.md`
- The file had two consecutive NOTE blocks covering the same topic (communication limits)
- The first NOTE correctly explains: "Communication limits are not applied to Smart Campaigns by default" and links to the relevant article
- The second NOTE immediately after contained only a bare link to the same article with no explanatory text — a clear leftover/duplicate
- Removed the second NOTE; the first NOTE already covers the content completely

## File changed

`help/marketo/product-docs/core-marketo-concepts/smart-campaigns/using-smart-campaigns/edit-qualification-rules-in-a-smart-campaign.md` — lines 32–34 removed