### PR TITLE
fix: correct MORELIKETHIS block indentation in understanding-period-costs.md

### DIFF
--- a/help/marketo/product-docs/core-marketo-concepts/programs/working-with-programs/understanding-period-costs.md
+++ b/help/marketo/product-docs/core-marketo-concepts/programs/working-with-programs/understanding-period-costs.md
@@ -57,7 +57,7 @@ Imagine an event, like a webinar, that occurs in March. New people are acquired 
    >
    >In summary - months with no defined period costs will roll "backwards" to the last one that was defined. If there is no prior period cost, the months will be rolled "forward" to the next one that has been defined. If a period cost has not been defined for _any_ months, reporting in RCE will not be available for the program.
 
-   >[!MORELIKETHIS]
-   >
-   >* [Using Period Costs in a Program](/help/marketo/product-docs/core-marketo-concepts/programs/working-with-programs/using-period-costs-in-a-program.md)
-   >* [Filter a Program Report by Period Cost](/help/marketo/product-docs/core-marketo-concepts/programs/program-performance-report/filter-a-program-report-by-period-cost.md)
+>[!MORELIKETHIS]
+>
+>* [Using Period Costs in a Program](/help/marketo/product-docs/core-marketo-concepts/programs/working-with-programs/using-period-costs-in-a-program.md)
+>* [Filter a Program Report by Period Cost](/help/marketo/product-docs/core-marketo-concepts/programs/program-performance-report/filter-a-program-report-by-period-cost.md)

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Fixes incorrect indentation of the `>[!MORELIKETHIS]` callout block at the end of `understanding-period-costs.md`
- The block was indented with 3 spaces, which nested it inside the last ordered-list item rather than rendering it as a top-level page element
- Moved to column 0 to match the standard pattern used across all other docs in this repo

## File changed

`help/marketo/product-docs/core-marketo-concepts/programs/working-with-programs/understanding-period-costs.md` — last 4 lines (indentation removed)