### PR TITLE
Fix clone program threshold: list cutoff is 1001 not 1000

### DIFF
--- a/help/marketo/product-docs/core-marketo-concepts/programs/working-with-programs/clone-a-program.md
+++ b/help/marketo/product-docs/core-marketo-concepts/programs/working-with-programs/clone-a-program.md
@@ -23,7 +23,7 @@ Quickly and easily clone an entire program and all its assets instead of manuall
 
    >[!NOTE]
    >
-   >See that [!UICONTROL NOTE] in the screenshot above? It means if you clone a program with 1000 or more people in a list, the list itself will get cloned, but it will be empty. If you clone a program with a list that contains 999 people or less, that list, along with all of its members, will show up in the cloned program.
+   >See that [!UICONTROL NOTE] in the screenshot above? It means if you clone a program with 1001 or more people in a list, the list itself will get cloned, but it will be empty. If you clone a program with a list that contains 1000 people or less, that list, along with all of its members, will show up in the cloned program.
 
 1. Enter a **[!UICONTROL Name]**.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #58. Corrects the static list member threshold for program cloning. A list with exactly 1000 members carries over successfully; only lists with 1001+ members are cloned empty. Verified by Adobe Marketo TSE (issue reporter).