### PR TITLE
Remove incorrect fuzzy matching tip from form field visibility doc

### DIFF
--- a/help/marketo/product-docs/demand-generation/forms/form-fields/dynamically-toggle-visibility-of-a-form-field.md
+++ b/help/marketo/product-docs/demand-generation/forms/form-fields/dynamically-toggle-visibility-of-a-form-field.md
@@ -37,9 +37,9 @@ One really cool feature of Marketo forms is that you can dynamically hide/show f
 
 1. Select the operator.
 
-   >[!TIP]
+   >[!NOTE]
    >
-   >This is cool because you can choose fuzzy matches like "[!UICONTROL starts with]."
+   >Available operators are: **Is**, **Is Not**, **Is Empty**, **Is Not Empty**, **Contains**, **Not Contains**.
 
    ![](assets/image2014-9-15-15-3a16-3a50.png)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #59. Removes a tip that incorrectly stated fuzzy matching (including "starts with") was available for form field visibility rules. Replaces it with a note listing the actual available operators: Is, Is Not, Is Empty, Is Not Empty, Contains, Not Contains.