### PR TITLE
Add missing Marketo IPs to setup-steps allowlist

### DIFF
--- a/help/marketo/getting-started/initial-setup/setup-steps.md
+++ b/help/marketo/getting-started/initial-setup/setup-steps.md
@@ -153,6 +153,8 @@ Configure your domain settings so landing pages use your company's domain instea
 
       130.248.173.0/24
 
+      130.248.244.88/29
+
       94.236.119.0/26
 
    >[!NOTE]

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #71. Adds `130.248.244.88/29` to the IP allowlist in setup-steps.md. This IP is listed on the Configure Protocols for Marketo Engage page (which setup-steps.md links to) but was absent from the setup-steps allowlist, causing inconsistency and potential customer misconfiguration.