### PR TITLE
Add SSL cert prerequisite warning before branded tracking links setup

### DIFF
--- a/help/marketo/getting-started/initial-setup/setup-steps.md
+++ b/help/marketo/getting-started/initial-setup/setup-steps.md
@@ -40,6 +40,10 @@ There are several measures you can take to ensure that the emails reach as many 
 
 If you're using Google Apps to host your corporate email, you won't be able to create abuse@ or postmaster@ emails under your domain. To get around this, you need to create groups named "abuse" and "postmaster". Users that are members of these groups will receive emails sent to those addresses (e.g., <postmaster@domain.com>). Detailed instructions for creating groups can be found [here](https://support.google.com/a/answer/33343#adminconsole){target="_blank"}.
 
+>[!IMPORTANT]
+>
+>Before configuring your branded tracking link CNAME, submit a Marketo Support case to request SSL certificate provisioning for your tracking domain. Do not add the DNS entry until Marketo confirms the certificate is provisioned — setting up the CNAME before the SSL cert is ready will cause tracking link failures.
+
 Choose a CNAME for email tracking links (choose one that is _different_ from the landing page CNAME you chose in Step 3). Some examples:
 
 * go2.[CompanyDomain].com

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+  
+{
+  "name": "Marketo Events Guide",
+  "version": "1.0.0",
+  "description": "Marketo Guide",
+  "author": "Kanika Gera",
+  "view_type": "mdbook",
+  "meta_keywords": "marketo",
+  "meta_description": "Marketo Developer Guide",
+  "publish_date": "14/07/2020",
+  "show_edit_github_banner": true,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "adobedocs/marketo.en/blob/master/README.md",
+      "title": "Marketo Readme Guide"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #66. Adds an IMPORTANT callout to the branded tracking links section clarifying that a Marketo Support case must be submitted to provision an SSL certificate before the DNS CNAME entry is created. Configuring the CNAME before the cert is provisioned causes tracking link failures. This sequencing is documented on the Configure Protocols page but was absent from the Setup Steps page where users first encounter tracking link configuration.